### PR TITLE
feat: add multi-host support via agents

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "echo ${nextRelease.version} > VERSION"
+        "prepareCmd": "echo ${nextRelease.version} > VERSION && sed -i 's/^version = .*/version = \"${nextRelease.version}\"/' pyproject.toml"
       }
     ],
     "@semantic-release/git"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /app
 COPY app/ ./app
 COPY main.py .
 COPY requirements.txt .
+COPY pyproject.toml .
 
 RUN rm -rf ./app/dashboard
 
@@ -26,5 +27,6 @@ COPY --from=dashboard_builder /dashboard/dist ./app/dashboard_build
 
 RUN mkdir -p ./app/data
 RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -e .
 
-CMD ["python", "main.py"]
+CMD ["server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ RUN apt-get update && \
 WORKDIR /app
 
 COPY app/ ./app
-COPY main.py .
-COPY requirements.txt .
+COPY main.py ./app/main.py
 COPY pyproject.toml .
 
 RUN rm -rf ./app/dashboard
@@ -26,7 +25,6 @@ RUN rm -rf ./app/dashboard
 COPY --from=dashboard_builder /dashboard/dist ./app/dashboard_build
 
 RUN mkdir -p ./app/data
-RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install --no-cache-dir -e .
 
 CMD ["server"]

--- a/README.md
+++ b/README.md
@@ -4,18 +4,13 @@ Ideal for environments where high availability matters and zombie containers are
 
 ## ✨ Key Features
 - Monitors Docker events in real-time.
-
 - Automatically restarts containers that are unhealthy or have unexpectedly exited.
-
 - Supports a restart policy configurable via environment variables.
-
-- Handles container dependencies using labels (com.monitor.depends.on).
-
+- Handles container dependencies using labels (`com.monitor.depends.on`).
 - Detailed, timezone-aware logging.
-
 - Supports container exclusion from restart policies.
-
 - Supports real-time [notifications](#-notifications) through [Apprise](https://github.com/caronc/apprise)
+- **Multi-host support via Agents** — monitor and manage containers across multiple machines from a single server.
 
 ## 🧭 How It Works
 
@@ -26,10 +21,95 @@ If the container has dependencies (defined through labels), it restarts those to
 Example: `[db] --> [backend] --> [frontend]` </br>
 If `db` goes down, the service will restart `db`, then `backend`, and finally `frontend`.
 
+## 🤖 Agents (Multi-host Support)
+
+Docker Surgeon supports a distributed mode where a central **server** manages multiple remote **agents**, each running on a different machine. This allows you to monitor and control containers across your entire infrastructure from a single point.
+
+### Architecture
+
+```
+[Server] ──HTTP/HTTPS──▶ [Agent A - Machine 1]
+         ──HTTP/HTTPS──▶ [Agent B - Machine 2]
+         ──HTTP/HTTPS──▶ [Agent C - Machine 3]
+```
+
+- The **server** runs the dashboard, the monitor logic, and communicates with all configured agents.
+- Each **agent** runs on a remote machine, exposes a secured REST API, and has access to the local Docker daemon via the Docker socket.
+
+### Running an Agent
+
+On each remote machine, run the agent with Docker:
+
+```yaml
+# docker-compose.yml (on the remote machine)
+services:
+  agent:
+    image: krystall0/docker-surgeon:latest
+    container_name: docker-surgeon-agent
+    command: agent
+    ports:
+      - "8001:8001"
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - AGENT_HOST=0.0.0.0
+      - AGENT_PORT=8001
+      - AGENT_TOKEN=yoursecuretokenhere
+```
+
+### Registering Agents on the Server
+
+On the server, configure agents via the `AGENTS_CONFIG` environment variable as a JSON array:
+
+```env
+AGENTS_CONFIG='[
+  {
+    "name": "machine-1",
+    "host": "192.168.1.50",
+    "port": 8001,
+    "token": "yoursecuretokenhere"
+  },
+  {
+    "name": "machine-2",
+    "host": "https://agent.example.com",
+    "port": 443,
+    "token": "anothersecuretoken",
+    "verify_ssl": true
+  }
+]'
+```
+
+Each agent entry supports the following fields:
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `host` | ✅ | — | IP address or domain of the agent. Prefix with `https://` for TLS. |
+| `name` | ❌ | `null` | Friendly name for the agent (used in logs). |
+| `port` | ❌ | `80` / `443` | Port the agent listens on. Auto-defaults to `443` if host starts with `https://`. |
+| `token` | ❌ | `null` | Bearer token to authenticate with the agent. Must match `AGENT_TOKEN` on the agent. |
+| `verify_ssl` | ❌ | `true` | Whether to verify the agent's SSL certificate. Set to `false` for self-signed certificates on internal networks. |
+
+### Agent Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `AGENT_HOST` | `127.0.0.1` | Address the agent binds to. Use `0.0.0.0` to accept remote connections. |
+| `AGENT_PORT` | `8001` | Port the agent listens on. |
+| `AGENT_TOKEN` | `null` | Secret token required to authenticate incoming requests. |
+
+### Security Considerations
+
+- Always set `AGENT_TOKEN` on every agent. Without it, the API is open to anyone who can reach the port.
+- If the agent is exposed to the internet, place it behind a reverse proxy (Nginx, Caddy) with HTTPS enabled.
+- For internal networks, HTTP with a strong token is generally sufficient.
+- If using a self-signed certificate, set `verify_ssl: false` on the server side for that agent.
+
+---
 
 ## 🧪 Environment Variables
 Configuration is handled through a `.env` file in the project root.
-Here’s an example:
+Here's an example:
 
 ```
 # Restart policy in JSON format
@@ -53,7 +133,6 @@ NOTIFICATION_TITLE="" #-> Edit the notification title as you wish
 NOTIFICATION_BODY="" #-> Edit the notification body as you wish
 
 
-
 ###############
 #   LOGGING   #   
 ###############
@@ -67,6 +146,23 @@ LOG_LEVEL= info
 # Adjust the timezone used for logging
 # e.g. Europe/Rome, America/New_York
 LOG_TIMEZONE=UTC
+
+AGENTS_CONFIG='[{"name": "my-server", "host": "192.168.1.50", "port": 8001, "token": "secret"}]'
+
+# This is used to specify if the agent should bind to a specific host. 
+# This is useful if the agent is running on the same machine as the main application and you want to restrict access to it. 
+# Possible values [127.0.0.1 | 0.0.0.0]
+# Default: 127.0.0.1
+AGENT_HOST=127.0.0.1 
+
+# This is the port on which the agent will listen for incoming requests. Make sure to set this to a free port. 
+# Possible values [ Any free port ]
+# Default: 8000
+AGENT_PORT=8000 
+
+# This is the token that the agent will use to authenticate incoming requests. Make sure to set this to a strong, unique value.
+# Default: None
+AGENT_TOKEN= yourtoken
 
 ```
 
@@ -328,3 +424,4 @@ Last {n_logs} logs:</br>
 ### ⚠️ Security Notes
 - Do **not** expose the dashboard over the internet without HTTPS and reverse proxy protections
 - Always use a strong admin password (preferably hashed)
+- Always set `AGENT_TOKEN` on every agent to prevent unauthorized access

--- a/app/agent/agent_client.py
+++ b/app/agent/agent_client.py
@@ -6,12 +6,13 @@ class AgentClient:
     def __init__(self, base_url: str, token: str, logger: logging.Logger):
         self.base_url = base_url
         self.token = token
+        self.verify_ssl: bool = True
         self.headers = {"Authorization": f"Bearer {token}"} if token else {}
         self.logger = logger
 
     async def _request(self, method: str, endpoint: str, **kwargs) -> dict:
         url = f"{self.base_url}{endpoint}"
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=self.verify_ssl) as client:
             try:
                 response = await client.request(method, url, headers=self.headers, **kwargs)
                 response.raise_for_status()
@@ -45,7 +46,7 @@ class AgentClient:
         
         while True:
             try:
-                async with httpx.AsyncClient(timeout=None) as client:
+                async with httpx.AsyncClient(verify=self.verify_ssl, timeout=None) as client:
                     try:
                         async with client.stream("GET", url, headers=self.headers) as response:
                             response.raise_for_status()

--- a/app/agent/agent_client.py
+++ b/app/agent/agent_client.py
@@ -1,5 +1,5 @@
 import httpx, json, asyncio, logging
-from typing import Callable, Awaitable
+from typing import Any
 
 
 class AgentClient:
@@ -26,13 +26,19 @@ class AgentClient:
     async def health_check(self) -> dict:
         return await self._request("GET", "/health")
 
-    async def list_containers(self) -> list[dict]:
+    async def list_containers(self) -> list[Any]:
         return await self._request("GET", "/containers")
 
-    async def restart_container(self, name: str) -> dict:
-        return await self._request("POST", f"/containers/{name}/restart")
+    async def restart_container(self, name: str | None = None, id: str | None = None) -> dict:
+        return await self._request("POST", f"/containers/restart", params={"name": name, "id": id} if name or id else {})
 
-    async def stream_events(self, callback: Callable[[dict], Awaitable[None]]):
+    async def get_container(self, name: str | None = None, id: str | None = None):
+        return await self._request("GET", "/containers/search", params={"name": name, "id": id} if name or id else {})
+
+    async def get_container_logs(self, name: str | None = None, id: str | None = None, tail: int = 10) -> str:
+        return await self._request("GET", "/containers/logs", params={"name": name, "id": id, "tail": tail} if name or id else {})
+    
+    async def stream_events(self):
         url = f"{self.base_url}/events/stream"
         delay = 2
         max_delay = 60
@@ -46,10 +52,11 @@ class AgentClient:
                             self.logger.info(f"[Agent {self.base_url}] Connected to event stream")
                             delay = 2  # Reset delay on successful connection
                             async for line in response.aiter_lines():
-                                if line.startswith("data:"):
+                                self.logger.debug(f"Received line from event stream: {line}")
+                                if line and len(line) > 0:
                                     try:
-                                        event = json.loads(line[5:].strip())
-                                        await callback(event)
+                                        event = json.loads(line[5:].strip())  # Remove "data: " prefix
+                                        yield event
                                     except json.JSONDecodeError as e:
                                         self.logger.error(f"Failed to decode event: {str(e)}")
                     except httpx.HTTPStatusError as e:

--- a/app/agent/agent_client.py
+++ b/app/agent/agent_client.py
@@ -1,0 +1,64 @@
+import httpx, json, asyncio, logging
+from typing import Callable, Awaitable
+
+
+class AgentClient:
+    def __init__(self, base_url: str, token: str, logger: logging.Logger):
+        self.base_url = base_url
+        self.token = token
+        self.headers = {"Authorization": f"Bearer {token}"} if token else {}
+        self.logger = logger
+
+    async def _request(self, method: str, endpoint: str, **kwargs) -> dict:
+        url = f"{self.base_url}{endpoint}"
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.request(method, url, headers=self.headers, **kwargs)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as e:
+                self.logger.error(f"HTTP error {e.response.status_code} for {method} {url}: {e.response.text}")
+                raise
+            except Exception as e:
+                self.logger.error(f"Error during {method} {url}: {str(e)}")
+                raise
+
+    async def health_check(self) -> dict:
+        return await self._request("GET", "/health")
+
+    async def list_containers(self) -> list[dict]:
+        return await self._request("GET", "/containers")
+
+    async def restart_container(self, name: str) -> dict:
+        return await self._request("POST", f"/containers/{name}/restart")
+
+    async def stream_events(self, callback: Callable[[dict], Awaitable[None]]):
+        url = f"{self.base_url}/events/stream"
+        delay = 2
+        max_delay = 60
+        
+        while True:
+            try:
+                async with httpx.AsyncClient(timeout=None) as client:
+                    try:
+                        async with client.stream("GET", url, headers=self.headers) as response:
+                            response.raise_for_status()
+                            self.logger.info(f"[Agent {self.base_url}] Connected to event stream")
+                            delay = 2  # Reset delay on successful connection
+                            async for line in response.aiter_lines():
+                                if line.startswith("data:"):
+                                    try:
+                                        event = json.loads(line[5:].strip())
+                                        await callback(event)
+                                    except json.JSONDecodeError as e:
+                                        self.logger.error(f"Failed to decode event: {str(e)}")
+                    except httpx.HTTPStatusError as e:
+                        self.logger.error(f"HTTP error {e.response.status_code} for streaming events: {e.response.text}")
+                        raise
+                    except Exception as e:
+                        self.logger.error(f"Error during streaming events: {str(e)}")
+                        raise
+            except Exception:
+                self.logger.info(f"[Agent {self.base_url}] Stream disconnected. Reconnecting to event stream in {delay} seconds...")
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, max_delay)

--- a/app/agent/agent_server.py
+++ b/app/agent/agent_server.py
@@ -1,32 +1,46 @@
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-import docker, asyncio, os
+import docker
+from app.backend.core.state import logger, config
 from app.agent.services import agent_service
-from app.backend.core.state import logger
 
 app = FastAPI()
 security = HTTPBearer()
-AGENT_TOKEN = os.getenv("AGENT_TOKEN", "")
 
 def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
-    if credentials.credentials != AGENT_TOKEN:
+    if credentials.credentials != config.agent_token:
         raise HTTPException(status_code=403, detail="Invalid token")
 
-client = docker.from_env()
+def get_docker_client():
+    return docker.from_env()
 
 @app.get("/health", dependencies=[Depends(verify_token)])
-def health_check():
+def health_check(client=Depends(get_docker_client)):
     client.ping()
-    return {"status": "ok", "host": os.getenv("AGENT_HOSTNAME", "unknown")}
+    return {"status": "ok", "host": config.agent_host}
 
 @app.get("/containers", dependencies=[Depends(verify_token)])
-def list_containers():
+def list_containers(client=Depends(get_docker_client)):
     return agent_service.getContainers(client)
 
-@app.post("/containers/{name}/restart", dependencies=[Depends(verify_token)])
-def restart_container(name: str):
+@app.get('/containers/search', dependencies=[Depends(verify_token)])
+def get_container(name: str | None = None, id: str | None = None, client=Depends(get_docker_client)):
+    if not name and not id:
+        raise HTTPException(status_code=400, detail="Either name or id must be provided")
+    return agent_service.getContainer(client, name, id)
+
+@app.get('/containers/logs', dependencies=[Depends(verify_token)])
+def get_container_logs(name: str | None = None, id: str | None = None, tail: int = 10, client=Depends(get_docker_client)):
+    if not name and not id:
+        raise HTTPException(status_code=400, detail="Either name or id must be provided")
+    return agent_service.getContainerLogs(client, name, id, tail)
+
+@app.post("/containers/restart", dependencies=[Depends(verify_token)])
+def restart_container(name: str | None = None, id: str | None = None, client=Depends(get_docker_client)):
+    if not name and not id:
+        raise HTTPException(status_code=400, detail="Either name or id must be provided")
     try:
-        return agent_service.restartContainer(client, name)
+        return agent_service.restartContainer(client, name, id)
     except docker.errors.NotFound:
         raise HTTPException(status_code=404, detail="Container not found")
     except docker.errors.APIError as e:
@@ -34,6 +48,6 @@ def restart_container(name: str):
     
 
 @app.get("/events/stream", dependencies=[Depends(verify_token)])
-async def event_stream():
+async def event_stream(client=Depends(get_docker_client)):
     from fastapi.responses import StreamingResponse
     return StreamingResponse(agent_service.getEvents(client, logger), media_type="text/event-stream")

--- a/app/agent/agent_server.py
+++ b/app/agent/agent_server.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI, Depends, HTTPException
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+import docker, asyncio, os
+from app.agent.services import agent_service
+from app.backend.core.state import logger
+
+app = FastAPI()
+security = HTTPBearer()
+AGENT_TOKEN = os.getenv("AGENT_TOKEN", "")
+
+def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    if credentials.credentials != AGENT_TOKEN:
+        raise HTTPException(status_code=403, detail="Invalid token")
+
+client = docker.from_env()
+
+@app.get("/health", dependencies=[Depends(verify_token)])
+def health_check():
+    client.ping()
+    return {"status": "ok", "host": os.getenv("AGENT_HOSTNAME", "unknown")}
+
+@app.get("/containers", dependencies=[Depends(verify_token)])
+def list_containers():
+    return agent_service.getContainers(client)
+
+@app.post("/containers/{name}/restart", dependencies=[Depends(verify_token)])
+def restart_container(name: str):
+    try:
+        return agent_service.restartContainer(client, name)
+    except docker.errors.NotFound:
+        raise HTTPException(status_code=404, detail="Container not found")
+    except docker.errors.APIError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    
+
+@app.get("/events/stream", dependencies=[Depends(verify_token)])
+async def event_stream():
+    from fastapi.responses import StreamingResponse
+    return StreamingResponse(agent_service.getEvents(client, logger), media_type="text/event-stream")

--- a/app/agent/services/agent_service.py
+++ b/app/agent/services/agent_service.py
@@ -1,31 +1,79 @@
+import asyncio
 import json
 from logging import Logger
 from docker import DockerClient
+from docker.models.containers import Container
 
 
-def getEvents(client: DockerClient, logger: Logger):
-    if(client is None):
+async def getEvents(client: DockerClient, logger: Logger):
+    if client is None:
         raise ValueError("Docker client is not initialized")
-    try:
-        events = client.events(decode=True)
-        for event in events:
-            if event.get("Type") == "container":
-                yield json.dumps(event) + "\n\n"
-    except Exception as e:
-        logger.error(f"Error while streaming events: {e}")
-        return
+    
+    queue = asyncio.Queue()
+    loop = asyncio.get_event_loop()
 
-def restartContainer(client: DockerClient, name: str):
+    def _stream():
+        try:
+            for event in client.events(decode=True):
+                if event.get("Type") == "container":
+                    loop.call_soon_threadsafe(queue.put_nowait, json.dumps(event))
+        except Exception as e:
+            loop.call_soon_threadsafe(queue.put_nowait, None)
+            logger.error(f"Error while streaming events: {e}")
+
+    loop.run_in_executor(None, _stream)
+
+    while True:
+        item = await queue.get()
+        if item is None:
+            break
+        yield f"data: {item}\n\n"
+
+def restartContainer(client: DockerClient, name: str | None = None, id: str | None = None) -> dict:
     try:
-        container = client.containers.get(name)
+        container = getContainer(client, name, id, return_as_dict=False)
         container.restart()
         return {"status": "restarted", "id": container.id, "name": container.name}
     except Exception as e:
         raise RuntimeError(f"Error restarting container: {e}")
 
-def getContainers(client: DockerClient):
+def getContainers(client: DockerClient) -> list[dict]:
     try:
         containers = client.containers.list(all=True)
-        return [{"id": c.id, "name": c.name, "status": c.status, "labels": c.labels} for c in containers]
+        return [_serialize_container(container) for container in containers]
     except Exception as e:
         raise RuntimeError(f"Error listing containers: {e}")
+    
+def getContainer(client: DockerClient, name: str | None = None, id: str | None = None, return_as_dict: bool = True) -> dict | Container:
+    try:
+        if name:
+            container = client.containers.get(name)
+        elif id:
+            container = client.containers.get(id)
+        else:
+            raise ValueError("Either name or id must be provided")
+        
+        if return_as_dict:
+            return _serialize_container(container)
+        return container
+    except Exception as e:
+        raise RuntimeError(f"Error getting container: {e}")
+
+def getContainerLogs(client: DockerClient, name: str | None = None, id: str | None = None, tail: int = 10) -> str:
+    try:
+        container = getContainer(client, name, id, return_as_dict=False)
+        logs = container.logs(tail=tail).decode('utf-8', errors='ignore')
+        return logs
+    except Exception as e:
+        raise RuntimeError(f"Error getting container logs: {e}")
+    
+def _serialize_container(container: Container) -> dict:
+    return {
+        "id": container.id,
+        "short_id": container.short_id,
+        "name": container.name,
+        "status": container.status,
+        "labels": container.labels,
+        "image": container.image.tags,
+        "attrs": container.attrs
+    }

--- a/app/agent/services/agent_service.py
+++ b/app/agent/services/agent_service.py
@@ -1,0 +1,31 @@
+import json
+from logging import Logger
+from docker import DockerClient
+
+
+def getEvents(client: DockerClient, logger: Logger):
+    if(client is None):
+        raise ValueError("Docker client is not initialized")
+    try:
+        events = client.events(decode=True)
+        for event in events:
+            if event.get("Type") == "container":
+                yield json.dumps(event) + "\n\n"
+    except Exception as e:
+        logger.error(f"Error while streaming events: {e}")
+        return
+
+def restartContainer(client: DockerClient, name: str):
+    try:
+        container = client.containers.get(name)
+        container.restart()
+        return {"status": "restarted", "id": container.id, "name": container.name}
+    except Exception as e:
+        raise RuntimeError(f"Error restarting container: {e}")
+
+def getContainers(client: DockerClient):
+    try:
+        containers = client.containers.list(all=True)
+        return [{"id": c.id, "name": c.name, "status": c.status, "labels": c.labels} for c in containers]
+    except Exception as e:
+        raise RuntimeError(f"Error listing containers: {e}")

--- a/app/agent/utils/agent_logger.py
+++ b/app/agent/utils/agent_logger.py
@@ -1,0 +1,5 @@
+import logging
+
+class AgentLogger(logging.LoggerAdapter):
+    def process(self, msg, kwargs):
+        return f"[Agent {self.extra.get('agent_name', 'Unknown')}] {msg}", kwargs

--- a/app/backend/core/agent_config.py
+++ b/app/backend/core/agent_config.py
@@ -2,13 +2,17 @@ from dataclasses import dataclass,field
 
 @dataclass
 class AgentConfig:
-    host: str
+    name: str | None = None
+    host: str | None = None
     port: int | None = None
     token: str | None = None
     verify_ssl: bool = True
     
     @property
     def base_url(self) -> str:
+        if self.host is None:
+            return ""
+
         if self.host.startswith("http://") or self.host.startswith("https://"):
             protocol = ""
         else:
@@ -22,6 +26,7 @@ class AgentConfig:
     @classmethod
     def from_dict(cls, data: dict) -> 'AgentConfig':
         return cls(
+            name=data.get("name", ""),
             host=data.get("host", ""),
             port=data.get("port", None),
             token=data.get("token", ""),

--- a/app/backend/core/agent_config.py
+++ b/app/backend/core/agent_config.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass,field
+
+@dataclass
+class AgentConfig:
+    host: str
+    port: int | None = None
+    token: str | None = None
+    verify_ssl: bool = True
+    
+    @property
+    def base_url(self) -> str:
+        if self.host.startswith("http://") or self.host.startswith("https://"):
+            protocol = ""
+        else:
+            protocol = "https://" if (self.port == 443) else "http://"
+            
+        default_port = 443 if self.host.startswith("https://") else 80
+        resolved_port = self.port if self.port is not None else default_port
+        
+        return f"{protocol}{self.host}:{resolved_port}"
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'AgentConfig':
+        return cls(
+            host=data.get("host", ""),
+            port=data.get("port", None),
+            token=data.get("token", ""),
+            verify_ssl=data.get("verify_ssl", True)
+        )
+    
+    
+    

--- a/app/backend/core/config.py
+++ b/app/backend/core/config.py
@@ -1,13 +1,15 @@
+from dataclasses import field, dataclass
 import json
 from threading import Lock
+from typing import Any
 from dotenv import load_dotenv
 from os import getenv
+from app.backend.core.agent_config import AgentConfig
 from app.backend.utils.string_utils import normalize_escapes
 
+@dataclass
 class Config:
-    _instance = None
-    _lock = Lock()
-    restart_policy:any
+    restart_policy: Any
     log_level:str
     timezone:str
     enable_dashboard:bool
@@ -19,44 +21,15 @@ class Config:
     notification_urls:list[str]
     notification_title:str | None
     notification_body:str | None
-    agents_config: list[dict] = []
+    agents_config: list[AgentConfig] = field(default_factory=list)
     agent_host: str | None = None
     agent_port: int | None = None
     agent_token: str | None = None
+    verify_ssl: bool = True
     
-    def __init__(self,
-                 restart_policy:any, 
-                 log_level:str, 
-                 timezone:str, 
-                 enable_dashboard:bool, 
-                 logs_amount:int, 
-                 dashboard_address:str, 
-                 dashboard_port:int, 
-                 admin_password: str | None, 
-                 enable_notifications:bool, 
-                 notification_urls:list[str], 
-                 notification_title:str | None, 
-                 notification_body:str | None, 
-                 agents_config: list[dict] = [], 
-                 agent_host: str | None = None, 
-                 agent_port: int | None = None, 
-                 agent_token: str | None = None):
-        self.restart_policy = restart_policy
-        self.log_level = log_level
-        self.timezone = timezone
-        self.enable_dashboard = enable_dashboard
-        self.logs_amount = logs_amount
-        self.dashboard_address = dashboard_address
-        self.dashboard_port = dashboard_port
-        self.admin_password = admin_password
-        self.enable_notifications = enable_notifications
-        self.notification_urls = notification_urls
-        self.notification_title = notification_title
-        self.notification_body = notification_body
-        self.agents_config = agents_config
-        self.agent_host = agent_host
-        self.agent_port = agent_port
-        self.agent_token = agent_token
+    _instance: "Config | None" = field(default=None, init=False, repr=False)
+    _lock: Lock = field(default_factory=Lock, init=False, repr=False)
+    
     @classmethod
     def load(cls):
         try:
@@ -82,10 +55,11 @@ class Config:
                 notification_urls= notification_urls,
                 notification_title = getenv("NOTIFICATION_TITLE", None),
                 notification_body = normalize_escapes(getenv("NOTIFICATION_BODY", None)),
-                agents_config = json.loads(getenv("AGENTS_CONFIG", "[]")),
+                agents_config = [AgentConfig.from_dict(agent) for agent in json.loads(getenv("AGENTS_CONFIG", "[]"))],
                 agent_host = getenv("AGENT_HOST", "127.0.0.1"),
                 agent_port = int(getenv("AGENT_PORT", "8000")),
-                agent_token = getenv("AGENT_TOKEN", None)
+                agent_token = getenv("AGENT_TOKEN", None),
+                verify_ssl = getenv("VERIFY_SSL", "true").strip().lower() == "true"
             )
         except Exception as e:
             raise Exception(f"Unable to load the config: {e}")
@@ -101,7 +75,3 @@ class Config:
             return cls._instance
         except Exception as e:
             raise Exception(e)
-        
-
-    def __repr__(self):
-        return f"Config:\nRestart Policy: {self.restart_policy}\nLog Level: {self.log_level}\nTime Zone: {self.timezone}\nEnable Dashboard: {self.enable_dashboard}\nDashboard Address: {self.dashboard_address}\nDashboard Port: {self.dashboard_port}\nLogs Amount: {self.logs_amount}\nEnable Notifications: {self.enable_notifications}\nAgents Config: {self.agents_config}\nAgent Host: {self.agent_host}\nAgent Port: {self.agent_port}\nAgent Token: {self.agent_token}"

--- a/app/backend/core/config.py
+++ b/app/backend/core/config.py
@@ -22,8 +22,25 @@ class Config:
     agents_config: list[dict] = []
     agent_host: str | None = None
     agent_port: int | None = None
+    agent_token: str | None = None
     
-    def __init__(self, restart_policy:any, log_level:str, timezone:str, enable_dashboard:bool, logs_amount:int, dashboard_address:str, dashboard_port:int, admin_password: str | None, enable_notifications:bool, notification_urls:list[str], notification_title:str | None, notification_body:str | None, agents_config: list[dict] = [], agent_host: str | None = None, agent_port: int | None = None):
+    def __init__(self,
+                 restart_policy:any, 
+                 log_level:str, 
+                 timezone:str, 
+                 enable_dashboard:bool, 
+                 logs_amount:int, 
+                 dashboard_address:str, 
+                 dashboard_port:int, 
+                 admin_password: str | None, 
+                 enable_notifications:bool, 
+                 notification_urls:list[str], 
+                 notification_title:str | None, 
+                 notification_body:str | None, 
+                 agents_config: list[dict] = [], 
+                 agent_host: str | None = None, 
+                 agent_port: int | None = None, 
+                 agent_token: str | None = None):
         self.restart_policy = restart_policy
         self.log_level = log_level
         self.timezone = timezone
@@ -39,7 +56,7 @@ class Config:
         self.agents_config = agents_config
         self.agent_host = agent_host
         self.agent_port = agent_port
-
+        self.agent_token = agent_token
     @classmethod
     def load(cls):
         try:
@@ -53,7 +70,7 @@ class Config:
                 notification_urls = []
             
             return cls(
-                restart_policy = json.loads(restart_policy),
+                restart_policy = json.loads(restart_policy) if len(restart_policy) > 0 else {},
                 log_level = getenv("LOG_LEVEL", "INFO").upper(),
                 timezone = getenv("LOG_TIMEZONE", "UTC"),
                 enable_dashboard = getenv("ENABLE_DASHBOARD", "false").strip().lower() == "true",
@@ -67,8 +84,8 @@ class Config:
                 notification_body = normalize_escapes(getenv("NOTIFICATION_BODY", None)),
                 agents_config = json.loads(getenv("AGENTS_CONFIG", "[]")),
                 agent_host = getenv("AGENT_HOST", "127.0.0.1"),
-                agent_port = int(getenv("AGENT_PORT", "8000"))
-
+                agent_port = int(getenv("AGENT_PORT", "8000")),
+                agent_token = getenv("AGENT_TOKEN", None)
             )
         except Exception as e:
             raise Exception(f"Unable to load the config: {e}")
@@ -87,5 +104,4 @@ class Config:
         
 
     def __repr__(self):
-        return f"Config:\nRestart Policy: {self.restart_policy}\nLog Level: {self.log_level}\nTime Zone: {self.timezone}\nEnable Dashboard: {self.enable_dashboard}\nDashboard Address: {self.dashboard_address}\nDashboard Port: {self.dashboard_port}\nLogs Amount: {self.logs_amount}\nEnable Notifications: {self.enable_notifications}\nAgents Config: {self.agents_config}\nAgent Host: {self.agent_host}\nAgent Port: {self.agent_port}"
-        
+        return f"Config:\nRestart Policy: {self.restart_policy}\nLog Level: {self.log_level}\nTime Zone: {self.timezone}\nEnable Dashboard: {self.enable_dashboard}\nDashboard Address: {self.dashboard_address}\nDashboard Port: {self.dashboard_port}\nLogs Amount: {self.logs_amount}\nEnable Notifications: {self.enable_notifications}\nAgents Config: {self.agents_config}\nAgent Host: {self.agent_host}\nAgent Port: {self.agent_port}\nAgent Token: {self.agent_token}"

--- a/app/backend/core/config.py
+++ b/app/backend/core/config.py
@@ -1,7 +1,7 @@
 from dataclasses import field, dataclass
 import json
 from threading import Lock
-from typing import Any
+from typing import Any, ClassVar
 from dotenv import load_dotenv
 from os import getenv
 from app.backend.core.agent_config import AgentConfig
@@ -9,6 +9,9 @@ from app.backend.utils.string_utils import normalize_escapes
 
 @dataclass
 class Config:
+    _instance: ClassVar["Config | None"] = None
+    _lock: ClassVar[Lock] = Lock()
+    
     restart_policy: Any
     log_level:str
     timezone:str
@@ -26,9 +29,6 @@ class Config:
     agent_port: int | None = None
     agent_token: str | None = None
     verify_ssl: bool = True
-    
-    _instance: "Config | None" = field(default=None, init=False, repr=False)
-    _lock: Lock = field(default_factory=Lock, init=False, repr=False)
     
     @classmethod
     def load(cls):

--- a/app/backend/core/config.py
+++ b/app/backend/core/config.py
@@ -28,7 +28,6 @@ class Config:
     agent_host: str | None = None
     agent_port: int | None = None
     agent_token: str | None = None
-    verify_ssl: bool = True
     
     @classmethod
     def load(cls):
@@ -58,8 +57,7 @@ class Config:
                 agents_config = [AgentConfig.from_dict(agent) for agent in json.loads(getenv("AGENTS_CONFIG", "[]"))],
                 agent_host = getenv("AGENT_HOST", "127.0.0.1"),
                 agent_port = int(getenv("AGENT_PORT", "8000")),
-                agent_token = getenv("AGENT_TOKEN", None),
-                verify_ssl = getenv("VERIFY_SSL", "true").strip().lower() == "true"
+                agent_token = getenv("AGENT_TOKEN", None)
             )
         except Exception as e:
             raise Exception(f"Unable to load the config: {e}")

--- a/app/backend/core/config.py
+++ b/app/backend/core/config.py
@@ -19,8 +19,11 @@ class Config:
     notification_urls:list[str]
     notification_title:str | None
     notification_body:str | None
+    agents_config: list[dict] = []
+    agent_host: str | None = None
+    agent_port: int | None = None
     
-    def __init__(self, restart_policy:any, log_level:str, timezone:str, enable_dashboard:bool, logs_amount:int, dashboard_address:str, dashboard_port:int, admin_password: str | None, enable_notifications:bool, notification_urls:list[str], notification_title:str | None, notification_body:str | None):
+    def __init__(self, restart_policy:any, log_level:str, timezone:str, enable_dashboard:bool, logs_amount:int, dashboard_address:str, dashboard_port:int, admin_password: str | None, enable_notifications:bool, notification_urls:list[str], notification_title:str | None, notification_body:str | None, agents_config: list[dict] = [], agent_host: str | None = None, agent_port: int | None = None):
         self.restart_policy = restart_policy
         self.log_level = log_level
         self.timezone = timezone
@@ -33,7 +36,10 @@ class Config:
         self.notification_urls = notification_urls
         self.notification_title = notification_title
         self.notification_body = notification_body
-    
+        self.agents_config = agents_config
+        self.agent_host = agent_host
+        self.agent_port = agent_port
+
     @classmethod
     def load(cls):
         try:
@@ -58,7 +64,11 @@ class Config:
                 enable_notifications = getenv("ENABLE_NOTIFICATIONS", "false").strip().lower() == "true",
                 notification_urls= notification_urls,
                 notification_title = getenv("NOTIFICATION_TITLE", None),
-                notification_body = normalize_escapes(getenv("NOTIFICATION_BODY", None))
+                notification_body = normalize_escapes(getenv("NOTIFICATION_BODY", None)),
+                agents_config = json.loads(getenv("AGENTS_CONFIG", "[]")),
+                agent_host = getenv("AGENT_HOST", "127.0.0.1"),
+                agent_port = int(getenv("AGENT_PORT", "8000"))
+
             )
         except Exception as e:
             raise Exception(f"Unable to load the config: {e}")
@@ -77,5 +87,5 @@ class Config:
         
 
     def __repr__(self):
-        return f"Config:\nRestart Policy: {self.restart_policy}\nLog Level: {self.log_level}\nTime Zone: {self.timezone}\nEnable Dashboard: {self.enable_dashboard}\nDashboard Address: {self.dashboard_address}\nDashboard Port: {self.dashboard_port}\nLogs Amount: {self.logs_amount}\nEnable Notifications: {self.enable_notifications}"
+        return f"Config:\nRestart Policy: {self.restart_policy}\nLog Level: {self.log_level}\nTime Zone: {self.timezone}\nEnable Dashboard: {self.enable_dashboard}\nDashboard Address: {self.dashboard_address}\nDashboard Port: {self.dashboard_port}\nLogs Amount: {self.logs_amount}\nEnable Notifications: {self.enable_notifications}\nAgents Config: {self.agents_config}\nAgent Host: {self.agent_host}\nAgent Port: {self.agent_port}"
         

--- a/app/backend/models/container_proxy.py
+++ b/app/backend/models/container_proxy.py
@@ -1,0 +1,9 @@
+class ContainerProxy:
+    def __init__(self, data: dict):
+        object.__setattr__(self, '_data', data)
+    
+    def __getattr__(self, name):
+        return self._data.get(name)
+    
+    def get(self, key, default=None):
+        return self._data.get(key, default)

--- a/app/backend/notifications/notification_manager.py
+++ b/app/backend/notifications/notification_manager.py
@@ -18,7 +18,7 @@ class NotificationManager:
         try:
             context = {
                 "container_name": container_name,
-                "logs": ANSI_ESCAPE.sub('',container_logs.decode('utf-8', errors='ignore')),
+                "logs": ANSI_ESCAPE.sub('',container_logs),
                 "exit_code": container_exit_code,
                 "n_logs": config.logs_amount
             }

--- a/app/backend/services/monitor_service.py
+++ b/app/backend/services/monitor_service.py
@@ -1,14 +1,15 @@
 import asyncio
-
+from typing import Any
 from docker import DockerClient, from_env
 from app.agent.agent_client import AgentClient
 from app.backend.core.config import Config
 from logging import Logger
 from datetime import datetime
-from time import sleep
+from app.backend.models.container_proxy import ContainerProxy
 from app.backend.schemas.crashed_container_schema import CrashedContainerBase
 from app.backend.repositories.crashed_container_repository import CrashedContainerRepository
 from app.backend.notifications.notification_manager import NotificationManager
+from docker.models.containers import Container
 
 
 ############
@@ -16,77 +17,45 @@ from app.backend.notifications.notification_manager import NotificationManager
 ############
 LABEL_NAME:str = "com.monitor.depends.on"
 
-
-def monitor_containers(config:Config, isAgent:bool, logger:Logger):
+def monitor_containers(
+    config:Config, 
+    logger:Logger, 
+    is_agent:bool = False, 
+    agent_client: AgentClient = None):
     
-    client = from_env()
-    if client is None:
-        print("[ERROR] - Failed to connect to Docker daemon.")
-        return
+    client:Any = None
     
-    _watch_container_events(client, config.restart_policy, config.logs_amount, isAgent, logger)
-
-def _watch_container_events(client: DockerClient, restart_policy:any, logs_amount:int, isAgent:bool , logger:Logger):
-    already_processed = set()
-    in_progress = set() 
-    
-    for event in client.events(decode=True):
+    if not is_agent:
         try:
-            if event.get("Type") != "container":
-                continue
-            
-            container_id = None
-            
-            # --- FIX: Safely retrieve container ID ---
-            # 1. Try to get the standard top-level ID
-            if 'id' in event:
-                container_id = event['id']
-            
-            # 2. If the standard ID is missing, check the Actor ID (common for exec/healthcheck events)
-            elif 'Actor' in event and 'ID' in event['Actor']:
-                container_id = event['Actor']['ID']
-            # ----------------------------------------
-            
-            if container_id is None:
-                logger.debug(f"Skipping container event with no ID: {event.get('Action')}")
-                continue
-            
-            container_id = container_id[:12] # Truncate to short ID
-            container_object = client.containers.get(container_id)
-            
-            if container_object is None:
-                logger.warning(f"Container with ID {container_id} not found.")
-                continue
-            
-            if _canBeRestarted(container_object, restart_policy, logger):
-                containerStatusAndExitCode = _getContainerStatusAndExitCode(container_object)
-                container_health_status = containerStatusAndExitCode["healthStatus"]
-                container_exit_code = containerStatusAndExitCode["exitCode"]
-                
-                logger.info(f"Container: {container_object.name} | ID: {container_id} | Status: {container_health_status} | Exit Code: {container_exit_code}. The container will be restarted including all its dependent containers")
-                crashed_container = CrashedContainerBase(container_id=container_id, container_name=container_object.name, logs=container_object.logs(tail=logs_amount))
-                CrashedContainerRepository.add_crashed_container(crashed_container, logger)
-                NotificationManager.container_crashed_event(container_name=container_object.name, container_logs=container_object.logs(tail=logs_amount), container_exit_code=container_exit_code)
-                _restart_with_graph(client, container_object, already_processed, in_progress, restart_policy, logger)
-
+            client = from_env()
         except Exception as e:
-            # Added logging of the full event for easier debugging of new issues
-            logger.error(f"Exception occurred: {e}. Event data: {event}")
+            logger.error(f"Failed to connect to Docker daemon: {e}")
+            return
+    else:
+        if agent_client is None:
+            logger.error("Agent client is not initialized for monitoring.")
+            return
+        client = None
+    
+    asyncio.run(_watch_container_events(client, config.restart_policy, config.logs_amount, logger, is_agent, agent_client))
 
-def _build_dependency_graph(client: DockerClient) -> dict:
-    graph = {}
-    all_containers = client.containers.list(all=True)
-
-    for container in all_containers:
-        depends_on = container.labels.get(LABEL_NAME)
-        if depends_on:
-            parents = [name.strip() for name in depends_on.split(",")]
-            for parent in parents:
-                if parent not in graph:
-                    graph[parent] = []
-                graph[parent].append(container.name)
-
-    return graph
+async def _watch_container_events(
+    client: DockerClient, 
+    restart_policy:any, 
+    logs_amount:int, 
+    logger:Logger, 
+    is_agent:bool = False,
+    agent_client: AgentClient = None):
+    
+    already_processed = set()
+    in_progress = set()
+    
+    if not is_agent:
+        for event in client.events(decode=True):
+            await _process_event(event, client=client, logger=logger, restart_policy=restart_policy, logs_amount=logs_amount, already_processed=already_processed, in_progress=in_progress)
+    else:
+        async for event in agent_client.stream_events():
+            await _process_event(event, is_agent=is_agent, agent_client=agent_client, logger=logger, restart_policy=restart_policy, logs_amount=logs_amount, already_processed=already_processed, in_progress=in_progress)
 
 def _topological_sort(graph: dict) -> list:
     already_visited = set()
@@ -105,14 +74,23 @@ def _topological_sort(graph: dict) -> list:
 
     return stack[::-1]  # Invert the results
 
-def _restart_with_graph(client: DockerClient, unhealthy_container, already_processed: set, in_progress: set, restart_policy:any, logger: Logger):
-    graph = _build_dependency_graph(client)
+async def _restart_with_graph(
+    client: DockerClient, 
+    unhealthy_container, 
+    already_processed: set, 
+    in_progress: set, 
+    restart_policy:any, 
+    logger: Logger, 
+    is_agent: bool = False,
+    agent_client: AgentClient = None):
+    
+    containers = client.containers.list(all=True) if not is_agent else [ContainerProxy(container) for container in await agent_client.list_containers()]
+    graph = _build_dependency_graph(containers)
     sorted_container_names = _topological_sort(graph)
     
     logger.debug(f"Graph: {graph}")
     logger.debug(f"Sorted container names: {sorted_container_names}")
     
-
     to_restart = [unhealthy_container.name]
     relevant = set(to_restart)
 
@@ -122,13 +100,13 @@ def _restart_with_graph(client: DockerClient, unhealthy_container, already_proce
         
         # Check if the container actually exists before trying to get it
         try:
-            ct = client.containers.get(container_name)
+            ct = await _get_container(client, name=container_name, is_agent=is_agent, agent_client=agent_client)
         except Exception:
             logger.debug(f"Dependent container {container_name} not found, skipping.")
             continue
 
 
-        if any(parent in relevant for parent in parents) and _canBeRestarted(ct, restart_policy, logger, True):
+        if any(parent in relevant for parent in parents) and await _canBeRestarted(ct, restart_policy, logger, check_on_children=True, is_agent=is_agent, agent_client=agent_client):
             to_restart.append(container_name)
             relevant.add(container_name)
 
@@ -143,31 +121,30 @@ def _restart_with_graph(client: DockerClient, unhealthy_container, already_proce
             continue
         in_progress.add(container_name)
         try:
-            container = client.containers.get(container_name)
+            container = await _get_container(client, name=container_name, is_agent=is_agent, agent_client=agent_client)
             logger.info(f"Restarting container {container.name} ({container.id[:12]})")
             
             if container.name in parents:
                 timeout = 60
-                container.restart()
+                await _restart_container(container, is_agent, agent_client)
                 logger.debug(f"Dependent containers found for {container.name}. Waiting until it is either 'running' or 'healthy'")
                 logger.debug(f"Waiting {timeout} seconds before aborting the restart operation")
                 operationInitTime = datetime.now()
                 while True:
-                    if _parentSuccessfullyRestarted(container, logger):
+                    if await _parentSuccessfullyRestarted(container, logger, is_agent=is_agent, agent_client=agent_client):
                         logger.debug(f"{container.name} restarted successfully. Proceeding to restart his children")
                         restarted_parents.add(container.name)
                         break
                     if _operationTimedOut(operationInitTime, datetime.now(), timeout, logger):
                         logger.warning(f"{container.name} did not recover in time - skipping dependent containers")
                         break
-                    sleep(2)
+                    await asyncio.sleep(2)
             else:
                 parents_of_child = [p for p, children in graph.items() if container.name in children]
                 
                 if not parents_of_child:
                     logger.info(f"Container {container.name} has no parent dependencies - restarting independently.")
-                    container.restart()
-                    
+                    await _restart_container(container, is_agent, agent_client)            
                 else:
                     parents_of_child.sort(key=lambda p: len(graph.get(p, [])), reverse=True)
                     unready_parents = [p for p in parents_of_child if p in to_restart and p not in restarted_parents]
@@ -178,7 +155,7 @@ def _restart_with_graph(client: DockerClient, unhealthy_container, already_proce
                         continue
                         
                     logger.info(f"Restarting child {container.name} ({container.id[:12]}) - parent(s) ready")
-                    container.restart()
+                    await _restart_container(container, is_agent, agent_client)
 
             logger.info(f"Successfully restarted {container.name}")
             already_processed.add(container_name)
@@ -188,30 +165,42 @@ def _restart_with_graph(client: DockerClient, unhealthy_container, already_proce
             in_progress.discard(container_name)
     
     if pending_children:
-        _retry_pending_children(client, pending_children, graph, restarted_parents, logger)
+        await _retry_pending_children(client, pending_children, graph, restarted_parents, logger, is_agent= is_agent, agent_client=agent_client)
     
 
     in_progress.clear()
     already_processed.clear()
 
-def _getContainerStatusAndExitCode(container):
+async def _getContainerStatusAndExitCode(container, logger: Logger, is_agent: bool = False, agent_client:AgentClient = None, ) -> dict:
     
     # Reload container object to get the latest state
-    container.reload()
+    if not is_agent:
+        container.reload()
+    else:
+        container = ContainerProxy(await agent_client.get_container(name=container.name))
     
-    container_health_status = container.attrs.get("State", {}).get("Health", {}).get("Status", "unknown")
-    container_exit_code = container.attrs.get("State", {}).get("ExitCode")
-    container_real_status = container.attrs.get("State", {}).get("Status", "unknown")
+    logger.debug(f"Container data: {container._data if hasattr(container, '_data') else container.attrs}")  # ← aggiungi questo
+    
+    attrs = container.attrs or {}
+    container_health_status = attrs.get("State", {}).get("Health", {}).get("Status", "unknown")
+    container_exit_code = attrs.get("State", {}).get("ExitCode")
+    container_real_status = attrs.get("State", {}).get("Status", "unknown")
 
     return {"healthStatus": container_health_status, "exitCode": container_exit_code, "realStatus": container_real_status}
 
-def _canBeRestarted(container, restart_policy:any, logger: Logger, checkOnChildren:bool = False) -> bool:
+async def _canBeRestarted(
+    container, 
+    restart_policy:any, 
+    logger: Logger, 
+    check_on_children:bool = False,
+    is_agent: bool = False,
+    agent_client: AgentClient = None) -> bool:
     
     if container.name in restart_policy.get("excludedContainers", []):
         logger.debug(f"{container.name} won't be restarted due to the restart policy")
         return False
     
-    containerStatusAndExitCode = _getContainerStatusAndExitCode(container)
+    containerStatusAndExitCode = await _getContainerStatusAndExitCode(container, logger, is_agent=is_agent, agent_client=agent_client)
     container_status = containerStatusAndExitCode["healthStatus"]
     container_exit_code = containerStatusAndExitCode["exitCode"]
     container_real_status = containerStatusAndExitCode["realStatus"]
@@ -219,12 +208,13 @@ def _canBeRestarted(container, restart_policy:any, logger: Logger, checkOnChildr
     logger.debug(f"CONTAINER NAME: {container.name} | STATUS: {container_status} | CODE: {container_exit_code} | REALSTATUS: {container_real_status}")
     
     # Use health status, then fall back to real status if health is unknown/missing from policy
-    policy = restart_policy["statuses"].get(container_status, {}) or restart_policy["statuses"].get(container_real_status, {})
+    
+    policy = {} if restart_policy == {} else (restart_policy["statuses"].get(container_status, {}) or restart_policy["statuses"].get(container_real_status, {}))
     
     isContainerUnhealthy: bool = container_real_status == "running" and container_status == "unhealthy"
     
     if not policy and not isContainerUnhealthy:
-        if checkOnChildren:
+        if check_on_children:
             return True # Allow children to be restarted if parent is being restarted
         logger.debug(f"No policy found. Container {container.name} won't be restarted")
         return False
@@ -238,18 +228,22 @@ def _canBeRestarted(container, restart_policy:any, logger: Logger, checkOnChildr
     # 2) Container matches the user-defined state and the exit code is not defined as excluded
     # 3) The parent of this container has to be restarted (checkOnChildren is True)
     
-    if isContainerUnhealthy or container_exit_code not in excluded_exit_codes or checkOnChildren:
+    if isContainerUnhealthy or container_exit_code not in excluded_exit_codes or check_on_children:
         logger.debug(f"{container.name} will be restarted soon")
         return True 
     
     return False
 
-def _parentSuccessfullyRestarted(container, logger:Logger) -> bool:
+async def _parentSuccessfullyRestarted(
+    container, 
+    logger:Logger,
+    is_agent: bool = False,
+    agent_client: AgentClient = None) -> bool:
     """
     Checks if the parent container has successfully restarted
     """
     
-    containerStatuses = _getContainerStatusAndExitCode(container)
+    containerStatuses = await _getContainerStatusAndExitCode(container, logger, is_agent=is_agent, agent_client=agent_client)
     # A container Health status is unknown when there's not healthcheck for it
     logger.debug(f"{container.name} statuses: {containerStatuses}")
     if (containerStatuses["healthStatus"] == "unknown" or containerStatuses["healthStatus"] == "healthy") and containerStatuses["realStatus"] == "running":
@@ -257,7 +251,11 @@ def _parentSuccessfullyRestarted(container, logger:Logger) -> bool:
     
     return False
 
-def _operationTimedOut(initialDate:datetime, endDate:datetime, timeout:int, logger:Logger) -> bool:
+def _operationTimedOut(
+    initialDate:datetime, 
+    endDate:datetime, 
+    timeout:int, 
+    logger:Logger) -> bool:
     """
     Checks if the operation time has exceeded the given timeout
     """
@@ -269,7 +267,16 @@ def _operationTimedOut(initialDate:datetime, endDate:datetime, timeout:int, logg
     
     return False
 
-def _retry_pending_children(client: DockerClient, pending_children: list, graph: dict, restarted_parents: set, logger: Logger, max_retries: int = 1, delay: int = 10):
+async def _retry_pending_children(
+    client: DockerClient, 
+    pending_children: list, 
+    graph: dict, 
+    restarted_parents: set, 
+    logger: Logger, 
+    max_retries: int = 1, 
+    delay: int = 10,
+    is_agent: bool = False,
+    agent_client: AgentClient = None):
     """
     Tries to restart pending children
     """
@@ -292,9 +299,9 @@ def _retry_pending_children(client: DockerClient, pending_children: list, graph:
                     still_pending.append(child_name)
                     continue
 
-                container = client.containers.get(child_name)
+                container = await _get_container(client, name=child_name, is_agent=is_agent, agent_client=agent_client)
                 logger.info(f"Retrying restart for {child_name} — parent(s) ready.")
-                container.restart()
+                await _restart_container(container, is_agent=is_agent, agent_client=agent_client)
                 logger.info(f"Successfully restarted {child_name}")
 
             except Exception as e:
@@ -304,20 +311,97 @@ def _retry_pending_children(client: DockerClient, pending_children: list, graph:
         pending_children = still_pending
         if pending_children and attempt < max_retries:
             logger.debug(f"{len(pending_children)} child container(s) still pending. Waiting {delay}s before next retry.")
-            sleep(delay)
+            await asyncio.sleep(delay)
         else:
             logger.info("All pending child containers have been restarted successfully.")
 
     if pending_children:
         logger.warning(f"Some child containers could not be restarted after {max_retries} retries: {pending_children}")
+
+def _build_dependency_graph(containers) -> dict:
+    graph = {}
+    for container in containers:
+        if isinstance(container, (dict, ContainerProxy)):
+            depends_on = (container.get("labels") or {}).get(LABEL_NAME) or (container.get("Labels") or {}).get(LABEL_NAME)
+            name = container.get("name") or container.get("Name")
+        else:
+            depends_on = container.labels.get(LABEL_NAME)
+            name = container.name
         
-        
-def _agent_watch_container_events(agent_client: AgentClient, restart_policy:any, logs_amount:int, logger:Logger):
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(agent_client.stream_events(lambda event: _handle_agent_event(event, agent_client, restart_policy, logs_amount, logger)))
+        if depends_on:
+            parents = [p.strip() for p in depends_on.split(",")]
+            for parent in parents:
+                if parent not in graph:
+                    graph[parent] = []
+                graph[parent].append(name)
+    return graph
+
+async def _restart_container(container, is_agent: bool = False, agent_client: AgentClient = None):
+    if not is_agent:
+        container.restart()
+    else:
+        await agent_client.restart_container(name=container.name)
+
+async def _get_container(client, name: str | None = None, id: str | None = None, is_agent: bool = False, agent_client: AgentClient = None) -> ContainerProxy | Container:
+    try:
+        if not is_agent:
+            return client.containers.get(name) if name else client.containers.get(id)
+        else:
+            container = await agent_client.get_container(name=name, id=id)
+            return ContainerProxy(container)  # Wrap the container data in a proxy for attribute access
+    except Exception as e:
+        raise RuntimeError(f"Error getting container: {e}")
     
-def _handle_agent_event(event: dict, agent_client: AgentClient, restart_policy:any, logs_amount:int, logger:Logger):
-    # This function will handle events received from the agent's event stream
-    # It should implement similar logic to _watch_container_events but adapted for the agent's API and event format
-    logger(f"Received event from agent: {event}")
-    pass
+async def _get_container_logs(client, name: str | None = None, id: str | None = None, tail: int = 10, is_agent: bool = False, agent_client: AgentClient = None) -> str:
+    try:
+        if not is_agent:
+            container = await _get_container(client, name, id, is_agent, agent_client)
+            return container.logs(tail=tail).decode('utf-8', errors='ignore')
+        else:
+            return await agent_client.get_container_logs(name=name, id=id, tail=tail)
+    except Exception as e:
+        raise RuntimeError(f"Error getting container logs: {e}")
+
+async def _process_event(event, logger: Logger, restart_policy:Any, logs_amount:int, already_processed:set, in_progress:set, client: DockerClient | None = None, is_agent: bool = False, agent_client: AgentClient = None):
+    try:
+        if event.get("Type") != "container":
+            return
+        
+        container_id = None
+        
+        # --- FIX: Safely retrieve container ID ---
+        # 1. Try to get the standard top-level ID
+        if 'id' in event:
+            container_id = event['id']
+        
+        # 2. If the standard ID is missing, check the Actor ID (common for exec/healthcheck events)
+        elif 'Actor' in event and 'ID' in event['Actor']:
+            container_id = event['Actor']['ID']
+        # ----------------------------------------
+        
+        if container_id is None:
+            logger.debug(f"Skipping container event with no ID: {event.get('Action')}")
+            return
+        
+        container_id = container_id[:12] # Truncate to short ID
+        container_object = await _get_container(client, id=container_id, is_agent=is_agent, agent_client=agent_client)
+        
+        if container_object is None:
+            logger.warning(f"Container with ID {container_id} not found.")
+            return
+        
+        if await _canBeRestarted(container_object, restart_policy, logger, is_agent=is_agent, agent_client=agent_client):
+            containerStatusAndExitCode = await _getContainerStatusAndExitCode(container_object, logger, is_agent=is_agent, agent_client=agent_client)
+            container_health_status = containerStatusAndExitCode["healthStatus"]
+            container_exit_code = containerStatusAndExitCode["exitCode"]
+            
+            logger.info(f"Container: {container_object.name} | ID: {container_id} | Status: {container_health_status} | Exit Code: {container_exit_code}. The container will be restarted including all its dependent containers")
+            logs = await _get_container_logs(client, id=container_id, tail=logs_amount, is_agent=is_agent, agent_client=agent_client)
+            crashed_container = CrashedContainerBase(container_id=container_id, container_name=container_object.name, logs=logs)
+            CrashedContainerRepository.add_crashed_container(crashed_container, logger)
+            NotificationManager.container_crashed_event(container_name=container_object.name, container_logs=logs, container_exit_code=container_exit_code)
+            await _restart_with_graph(client, container_object, already_processed, in_progress, restart_policy, logger, is_agent=is_agent, agent_client=agent_client)
+
+    except Exception as e:
+        # Added logging of the full event for easier debugging of new issues
+        logger.error(f"Exception occurred: {e}. Event data: {event}")

--- a/app/backend/services/monitor_service.py
+++ b/app/backend/services/monitor_service.py
@@ -179,8 +179,6 @@ async def _getContainerStatusAndExitCode(container, logger: Logger, is_agent: bo
     else:
         container = ContainerProxy(await agent_client.get_container(name=container.name))
     
-    logger.debug(f"Container data: {container._data if hasattr(container, '_data') else container.attrs}")  # ← aggiungi questo
-    
     attrs = container.attrs or {}
     container_health_status = attrs.get("State", {}).get("Health", {}).get("Status", "unknown")
     container_exit_code = attrs.get("State", {}).get("ExitCode")

--- a/app/backend/services/monitor_service.py
+++ b/app/backend/services/monitor_service.py
@@ -1,4 +1,7 @@
+import asyncio
+
 from docker import DockerClient, from_env
+from app.agent.agent_client import AgentClient
 from app.backend.core.config import Config
 from logging import Logger
 from datetime import datetime
@@ -14,18 +17,18 @@ from app.backend.notifications.notification_manager import NotificationManager
 LABEL_NAME:str = "com.monitor.depends.on"
 
 
-def monitor_containers(config:Config, logger:Logger):
+def monitor_containers(config:Config, isAgent:bool, logger:Logger):
     
     client = from_env()
     if client is None:
         print("[ERROR] - Failed to connect to Docker daemon.")
         return
     
-    _watch_container_events(client, config.restart_policy, config.logs_amount, logger)
+    _watch_container_events(client, config.restart_policy, config.logs_amount, isAgent, logger)
 
-def _watch_container_events(client: DockerClient, restart_policy:any, logs_amount:int, logger:Logger):
+def _watch_container_events(client: DockerClient, restart_policy:any, logs_amount:int, isAgent:bool , logger:Logger):
     already_processed = set()
-    in_progress = set()
+    in_progress = set() 
     
     for event in client.events(decode=True):
         try:
@@ -55,8 +58,8 @@ def _watch_container_events(client: DockerClient, restart_policy:any, logs_amoun
                 logger.warning(f"Container with ID {container_id} not found.")
                 continue
             
-            if _canBeRestarted(client, container_object, restart_policy, logger):
-                containerStatusAndExitCode = _getContainerStatusAndExitCode(client, container_object)
+            if _canBeRestarted(container_object, restart_policy, logger):
+                containerStatusAndExitCode = _getContainerStatusAndExitCode(container_object)
                 container_health_status = containerStatusAndExitCode["healthStatus"]
                 container_exit_code = containerStatusAndExitCode["exitCode"]
                 
@@ -69,7 +72,6 @@ def _watch_container_events(client: DockerClient, restart_policy:any, logs_amoun
         except Exception as e:
             # Added logging of the full event for easier debugging of new issues
             logger.error(f"Exception occurred: {e}. Event data: {event}")
-
 
 def _build_dependency_graph(client: DockerClient) -> dict:
     graph = {}
@@ -103,7 +105,6 @@ def _topological_sort(graph: dict) -> list:
 
     return stack[::-1]  # Invert the results
 
-
 def _restart_with_graph(client: DockerClient, unhealthy_container, already_processed: set, in_progress: set, restart_policy:any, logger: Logger):
     graph = _build_dependency_graph(client)
     sorted_container_names = _topological_sort(graph)
@@ -127,7 +128,7 @@ def _restart_with_graph(client: DockerClient, unhealthy_container, already_proce
             continue
 
 
-        if any(parent in relevant for parent in parents) and _canBeRestarted(client, ct, restart_policy, logger, True):
+        if any(parent in relevant for parent in parents) and _canBeRestarted(ct, restart_policy, logger, True):
             to_restart.append(container_name)
             relevant.add(container_name)
 
@@ -152,7 +153,7 @@ def _restart_with_graph(client: DockerClient, unhealthy_container, already_proce
                 logger.debug(f"Waiting {timeout} seconds before aborting the restart operation")
                 operationInitTime = datetime.now()
                 while True:
-                    if _parentSuccessfullyRestarted(client, container, logger):
+                    if _parentSuccessfullyRestarted(container, logger):
                         logger.debug(f"{container.name} restarted successfully. Proceeding to restart his children")
                         restarted_parents.add(container.name)
                         break
@@ -192,9 +193,8 @@ def _restart_with_graph(client: DockerClient, unhealthy_container, already_proce
 
     in_progress.clear()
     already_processed.clear()
-    
 
-def _getContainerStatusAndExitCode(client, container):
+def _getContainerStatusAndExitCode(container):
     
     # Reload container object to get the latest state
     container.reload()
@@ -205,13 +205,13 @@ def _getContainerStatusAndExitCode(client, container):
 
     return {"healthStatus": container_health_status, "exitCode": container_exit_code, "realStatus": container_real_status}
 
-def _canBeRestarted(client, container, restart_policy:any, logger: Logger, checkOnChildren:bool = False) -> bool:
+def _canBeRestarted(container, restart_policy:any, logger: Logger, checkOnChildren:bool = False) -> bool:
     
     if container.name in restart_policy.get("excludedContainers", []):
         logger.debug(f"{container.name} won't be restarted due to the restart policy")
         return False
     
-    containerStatusAndExitCode = _getContainerStatusAndExitCode(client, container)
+    containerStatusAndExitCode = _getContainerStatusAndExitCode(container)
     container_status = containerStatusAndExitCode["healthStatus"]
     container_exit_code = containerStatusAndExitCode["exitCode"]
     container_real_status = containerStatusAndExitCode["realStatus"]
@@ -244,12 +244,12 @@ def _canBeRestarted(client, container, restart_policy:any, logger: Logger, check
     
     return False
 
-def _parentSuccessfullyRestarted(client, container, logger:Logger) -> bool:
+def _parentSuccessfullyRestarted(container, logger:Logger) -> bool:
     """
     Checks if the parent container has successfully restarted
     """
     
-    containerStatuses = _getContainerStatusAndExitCode(client, container)
+    containerStatuses = _getContainerStatusAndExitCode(container)
     # A container Health status is unknown when there's not healthcheck for it
     logger.debug(f"{container.name} statuses: {containerStatuses}")
     if (containerStatuses["healthStatus"] == "unknown" or containerStatuses["healthStatus"] == "healthy") and containerStatuses["realStatus"] == "running":
@@ -310,3 +310,14 @@ def _retry_pending_children(client: DockerClient, pending_children: list, graph:
 
     if pending_children:
         logger.warning(f"Some child containers could not be restarted after {max_retries} retries: {pending_children}")
+        
+        
+def _agent_watch_container_events(agent_client: AgentClient, restart_policy:any, logs_amount:int, logger:Logger):
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(agent_client.stream_events(lambda event: _handle_agent_event(event, agent_client, restart_policy, logs_amount, logger)))
+    
+def _handle_agent_event(event: dict, agent_client: AgentClient, restart_policy:any, logs_amount:int, logger:Logger):
+    # This function will handle events received from the agent's event stream
+    # It should implement similar logic to _watch_container_events but adapted for the agent's API and event format
+    logger(f"Received event from agent: {event}")
+    pass

--- a/example.env
+++ b/example.env
@@ -36,8 +36,32 @@ LOG_TIMEZONE=UTC
 ###############
 #   AGENT     #   
 ###############
-AGENTS_CONFIG = '[{host: "", port: 8000, token: "", verify_ssl: true}]' #-> This is the configuration for the agent that will execute the actions. You can specify multiple agents as [{"host": "ip1", "port": port1, "token": "    token1", "verify_ssl": true}, {"host": "ip2", "port": port2, "token": "token2", "verify_ssl": false}]
-AGENT_HOST=127.0.0.1 #-> This is used to specify if the agent should bind to a specific host. This is useful if the agent is running on the same machine as the main application and you want to restrict access to it. Possible values [127.0.0.1 | 0.0.0.0]
-AGENT_PORT=8000 #-> This is the port on which the agent will listen for incoming requests. Make sure to set this to a free port. Possible values [ Any free port ]
-AGENT_TOKEN= #-> This is the token that the agent will use to authenticate incoming requests. Make sure to set this to a strong, unique value.
-AGENT_VERIFY_SSL=True #-> This specifies whether the agent should verify SSL certificates when making requests to other services. Set this to False if you are using self-signed certificates or if you want to disable SSL verification for any reason. Possible values [True | False]
+
+# This is the configuration for the agent that will execute the actions. 
+# You can specify multiple agents as [{"host": "ip1", "port": port1, "token": "    token1", "verify_ssl": true}, {"host": "ip2", "port": port2, "token": "token2", "verify_ssl": false}]
+#
+# Detailed explanation of each field:
+# | Field Name   | Description                                                                                                                                                                                                                             | Example Values
+# |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------
+# | host         | The IP address or hostname where the agent is running. This is the address that the main application will use to send requests to the agent.                                                                                            | local ip, https://example.com, etc.
+# | port         | The port on which the agent is listening for incoming requests. Make sure to set this to a free port.                                                                                                                                   | Any free port
+# | token        | The token that the agent will use to authenticate incoming requests. Make sure to set this to a strong, unique value.                                                                                                                   | Any strong, unique string
+# | verify_ssl   | This specifies whether the agent client should verify SSL certificates when making requests to the agent server. Set this to False if you are using self-signed certificates or if you want to disable SSL verification for any reason. | True or False
+#
+# Default: []
+AGENTS_CONFIG = '[{host: "", port: 8000, token: "", verify_ssl: true}]' 
+
+# This is used to specify if the agent should bind to a specific host. 
+# This is useful if the agent is running on the same machine as the main application and you want to restrict access to it. 
+# Possible values [127.0.0.1 | 0.0.0.0]
+# Default: 127.0.0.1
+AGENT_HOST=127.0.0.1 
+
+# This is the port on which the agent will listen for incoming requests. Make sure to set this to a free port. 
+# Possible values [ Any free port ]
+# Default: 8000
+AGENT_PORT=8000 
+
+# This is the token that the agent will use to authenticate incoming requests. Make sure to set this to a strong, unique value.
+# Default: None
+AGENT_TOKEN= yourtoken

--- a/example.env
+++ b/example.env
@@ -32,3 +32,12 @@ LOG_LEVEL= info
 # Adjust the timezone used for logging
 # e.g. Europe/Rome, America/New_York
 LOG_TIMEZONE=UTC
+
+###############
+#   AGENT     #   
+###############
+AGENTS_CONFIG = '[{host: "", port: 8000, token: "", verify_ssl: true}]' #-> This is the configuration for the agent that will execute the actions. You can specify multiple agents as [{"host": "ip1", "port": port1, "token": "    token1", "verify_ssl": true}, {"host": "ip2", "port": port2, "token": "token2", "verify_ssl": false}]
+AGENT_HOST=127.0.0.1 #-> This is used to specify if the agent should bind to a specific host. This is useful if the agent is running on the same machine as the main application and you want to restrict access to it. Possible values [127.0.0.1 | 0.0.0.0]
+AGENT_PORT=8000 #-> This is the port on which the agent will listen for incoming requests. Make sure to set this to a free port. Possible values [ Any free port ]
+AGENT_TOKEN= #-> This is the token that the agent will use to authenticate incoming requests. Make sure to set this to a strong, unique value.
+AGENT_VERIFY_SSL=True #-> This specifies whether the agent should verify SSL certificates when making requests to other services. Set this to False if you are using self-signed certificates or if you want to disable SSL verification for any reason. Possible values [True | False]

--- a/main.py
+++ b/main.py
@@ -4,10 +4,10 @@ from app.backend.core import state
 from app.backend.core.logger import get_bootstrap_logger, get_logger
 from app.backend.services.monitor_service import monitor_containers
 from threading import Thread
+import uvicorn
 
 
-if __name__  == '__main__':
-    
+def bootstrap():
     logger = get_bootstrap_logger()
     
     try:
@@ -21,8 +21,31 @@ if __name__  == '__main__':
     logger.info(f"Config successfully loaded!\n{config}")
     state.logger = logger
     init_db(logger)
+    
+    return config, logger
+
+def run_agent():
+    config, logger = bootstrap()
+    
+    state.logger = logger
+    state.config = config
+    
+    from app.agent.agent_server import app as agent_app
+    logger.info(f"Starting agent server at {config.agent_host}:{config.agent_port}")
+    uvicorn.run(agent_app, host=config.agent_host, port=config.agent_port)
+
+def run_server():
+    config, logger = bootstrap()
+    
     worker = Thread(target=monitor_containers, args=(config, logger), daemon=True)
     worker.start()
+                
+    for agent in config.agents_config:
+        logger.info(f"Starting agent client for {agent['name']} at {agent['host']}:{agent['port']}")
+        from app.agent.agent_client import AgentClient
+        agent_client = AgentClient(base_url=f"http://{agent['host']}:{agent['port']}", token=agent.get("token", ""), logger=logger)
+        worker = Thread(target=agent_client.stream_events, args=(monitor_containers), daemon=True)
+        worker.start()
     
     if config.enable_dashboard:
         import uvicorn
@@ -47,12 +70,8 @@ if __name__  == '__main__':
         def serve_dashboard(full_path:str):
             index_path = path.join(f"{DASHBOARD_DIR}", "index.html")
             return FileResponse(index_path)
-             
+            
         uvicorn.run(app, host=config.dashboard_address, port=config.dashboard_port, reload=False)
-        
         logger.info("FastAPI server started")
-    
-    worker.join()
-    
-    
+
     

--- a/main.py
+++ b/main.py
@@ -36,16 +36,20 @@ def run_agent():
 
 def run_server():
     config, logger = bootstrap()
+    workers = []
     
     worker = Thread(target=monitor_containers, args=(config, logger), daemon=True)
     worker.start()
+    workers.append(worker)
                 
     for agent in config.agents_config:
         logger.info(f"Starting agent client for {agent['name']} at {agent['host']}:{agent['port']}")
         from app.agent.agent_client import AgentClient
         agent_client = AgentClient(base_url=f"http://{agent['host']}:{agent['port']}", token=agent.get("token", ""), logger=logger)
-        worker = Thread(target=agent_client.stream_events, args=(monitor_containers), daemon=True)
+        
+        worker = Thread(target=monitor_containers, args=(config, logger, True, agent_client), daemon=True)
         worker.start()
+        workers.append(worker)
     
     if config.enable_dashboard:
         import uvicorn
@@ -74,4 +78,6 @@ def run_server():
         uvicorn.run(app, host=config.dashboard_address, port=config.dashboard_port, reload=False)
         logger.info("FastAPI server started")
 
+    for worker in workers:
+        worker.join()
     

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from app.backend.core.config import Config
 from app.backend.core import state
 from app.backend.core.logger import get_bootstrap_logger, get_logger
 from app.backend.services.monitor_service import monitor_containers
+from app.agent.utils.agent_logger import AgentLogger
 from threading import Thread
 import uvicorn
 
@@ -44,10 +45,10 @@ def run_server():
     workers.append(worker)
                 
     for agent in config.agents_config:
-        logger.info(f"Starting agent client for {agent['name']} at {agent['host']}:{agent['port']}")
+        logger.info(f"Starting agent client for {agent.name} at {agent.host}:{agent.port}")
         from app.agent.agent_client import AgentClient
-        agent_config = AgentConfig.from_dict(agent)
-        agent_client = AgentClient(base_url=agent_config.base_url, token=agent_config.token, logger=logger)
+        logger = AgentLogger(logger, extra={"agent_name": agent.name})
+        agent_client = AgentClient(base_url=agent.base_url, token=agent.token, logger=logger)
         
         worker = Thread(target=monitor_containers, args=(config, logger, True, agent_client), daemon=True)
         worker.start()

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+from app.backend.core.agent_config import AgentConfig
 from app.backend.core.database import init_db
 from app.backend.core.config import Config
 from app.backend.core import state
@@ -45,7 +46,8 @@ def run_server():
     for agent in config.agents_config:
         logger.info(f"Starting agent client for {agent['name']} at {agent['host']}:{agent['port']}")
         from app.agent.agent_client import AgentClient
-        agent_client = AgentClient(base_url=f"http://{agent['host']}:{agent['port']}", token=agent.get("token", ""), logger=logger)
+        agent_config = AgentConfig.from_dict(agent)
+        agent_client = AgentClient(base_url=agent_config.base_url, token=agent_config.token, logger=logger)
         
         worker = Thread(target=monitor_containers, args=(config, logger, True, agent_client), daemon=True)
         worker.start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,91 @@
+[build-system]
+requires = ["setuptools >= 77.0.3"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "docker-surgeon"
+version = "1.4.2"
+authors = [
+  { name="kRYstall9" },
+]
+description = "Monitor and restart unhealthy, killed, or stopped Docker containers according to a user-defined restart policy, including any dependent containers."
+readme = "README.md"
+requires-python = ">=3.13"
+classifiers = [
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: OS Independent",
+]
+license = "MIT"
+license-files = ["LICEN[CS]E*"]
+dependencies = [
+  "annotated-doc==0.0.3",
+  "annotated-types==0.7.0",
+  "anyio==4.11.0",
+  "apprise==1.9.5",
+  "argon2-cffi==25.1.0",
+  "argon2-cffi-bindings==25.1.0",
+  "bcrypt==5.0.0",
+  "certifi==2025.10.5",
+  "cffi==2.0.0",
+  "charset-normalizer==3.4.4",
+  "click==8.3.0",
+  "colorama==0.4.6",
+  "dnspython==2.8.0",
+  "docker==7.1.0",
+  "email-validator==2.3.0",
+  "fastapi==0.121.0",
+  "fastapi-cli==0.0.14",
+  "fastapi-cloud-cli==0.3.1",
+  "greenlet==3.2.4",
+  "h11==0.16.0",
+  "httpcore==1.0.9",
+  "httptools==0.7.1",
+  "httpx==0.28.1",
+  "idna==3.11",
+  "Jinja2==3.1.6",
+  "Markdown==3.10",
+  "markdown-it-py==4.0.0",
+  "MarkupSafe==3.0.3",
+  "mdurl==0.1.2",
+  "oauthlib==3.3.1",
+  "pycparser==2.23",
+  "pydantic==2.12.3",
+  "pydantic_core==2.41.4",
+  "Pygments==2.19.2",
+  "PyJWT==2.10.1",
+  "python-dotenv==1.1.1",
+  "python-multipart==0.0.20",
+  "pytz==2025.2",
+  'pywin32==311; sys_platform == "win32"',
+  "PyYAML==6.0.3",
+  "requests==2.32.5",
+  "requests-oauthlib==2.0.0",
+  "rich==14.2.0",
+  "rich-toolkit==0.15.1",
+  "rignore==0.7.4",
+  "sentry-sdk==2.43.0",
+  "shellingham==1.5.4",
+  "sniffio==1.3.1",
+  "SQLAlchemy==2.0.44",
+  "starlette==0.49.3",
+  "typer==0.20.0",
+  "typing-inspection==0.4.2",
+  "typing_extensions==4.15.0",
+  "tzdata==2025.2",
+  "urllib3==2.5.0",
+  "uvicorn==0.38.0",
+  "watchfiles==1.1.1",
+  "websockets==15.0.1"
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["app*"]
+
+[project.urls]
+Homepage = "https://github.com/kRYstall9/docker-surgeon"
+Issues = "https://github.com/kRYstall9/docker-surgeon/issues"
+
+[project.scripts]
+agent = "app.main:run_agent"
+server = "app.main:run_server"


### PR DESCRIPTION
## Overview
Adds a distributed agent architecture that allows a central server to monitor and manage containers across multiple machines.
### How it works
A lightweight agent process can be run on each remote machine, exposing a secured REST API backed by the local Docker socket.
The server communicates with agents over HTTP/HTTPS using bearer token authentication
Agents are registered on the server via the `AGENTS_CONFIG`  environment variable as a JSON array

### New environment variables
Variable | Default | Description
-- | -- | --
AGENT_HOST | 127.0.0.1 | Address the agent binds to
AGENT_PORT | 8001 | Port the agent listens on
AGENT_TOKEN | null | Secret token for authenticating incoming requests

### Notes
`AGENT_TOKEN` should always be set. Without it the API is open to anyone who can reach the port
For internet-exposed agents, a reverse proxy with HTTPS is recommended
`verify_ssl: false`  is available on the server side for self-signed certificates on internal networks

Resolves #4 